### PR TITLE
Edit java

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -39,7 +39,6 @@ $(function() {
     .done(function(data){
       var html = buildHTML(data);
       $('.chat.messages').append(html);
-      $('.chat.messages').animate({scrollTop: $('.chat.messages')[0].scrollHeight}, "fast");
       $('.form__message').val('');
     })
     .fail(function(){
@@ -72,5 +71,5 @@ $(function() {
     else {
       clearInterval(interval);
     }
-  } , 5000 );
+  } , 1000 );
 });


### PR DESCRIPTION
 # What
メール送信時にフォームエリアに入力した文字が消えるようにする
 # Why
メール送信時にフォームエリアの文字が消えないと、メールそのものが送られた感じがしなかったため、修正を行った。